### PR TITLE
Remove extraneous paths from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "lib/"
   ],
   "scripts": {
-    "lint": "./node_modules/.bin/eslint .",
-    "test": "npm run lint && ./node_modules/.bin/mocha",
-    "coverage": "rm -rf coverage && node_modules/.bin/istanbul cover node_modules/.bin/_mocha",
-    "report-coveralls": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "lint": "eslint .",
+    "test": "npm run lint && mocha",
+    "coverage": "rm -rf coverage && istanbul cover _mocha",
+    "report-coveralls": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "devDependencies": {
     "co": "^4.6",


### PR DESCRIPTION
from https://docs.npmjs.com/cli/run-script

> In addition to the shell's pre-existing PATH, npm run adds
> node_modules/.bin to the PATH provided to scripts.
