### PR TITLE
Build with babel into /es5 for older versions of node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 *.log
 *.swp
+es5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - '0.10'
+  - '0.12'
   - '4'
   - '6'
 sudo: false

--- a/package.json
+++ b/package.json
@@ -11,19 +11,38 @@
   "license": "MIT",
   "files": [
     "index.js",
-    "lib/"
+    "lib/",
+    "es5/index.js",
+    "es5/lib/"
   ],
   "scripts": {
-    "lint": "eslint .",
-    "test": "npm run lint && mocha",
+    "build-es5": "rm -r es5 > /dev/null; babel -s true ./index.js ./lib/**/*.js -d es5 && babel -s true --plugins transform-regenerator ./test/**/*.js -d es5",
+    "prepublish": "npm run build-es5",
+    "lint": "eslint ./index.js ./{lib,test}/**/*.js",
+    "pretest": "npm run lint",
+    "test": "[ `echo $npm_config_node_version | cut -d. -f1` -eq 0 ] && npm run test-es5 || mocha",
+    "test-es5": "mocha --require regenerator-runtime/runtime --require any-promise/register/bluebird es5/test/**/*.js",
     "coverage": "rm -rf coverage && istanbul cover _mocha",
     "report-coveralls": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "devDependencies": {
+    "any-promise": "^1.3.0",
+    "babel-cli": "^6.10.1",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
+    "babel-plugin-transform-es2015-block-scoping": "^6.10.1",
+    "babel-plugin-transform-regenerator": "^6.9.0",
+    "bluebird": "^3.4.1",
     "co": "^4.6",
     "coveralls": "^2.11.9",
     "eslint": "~2.11.1",
     "istanbul": "^0.4.3",
-    "mocha": "^2.5.3"
+    "mocha": "^2.5.3",
+    "regenerator-runtime": "^0.9.5"
+  },
+  "babel": {
+    "plugins": [
+      "transform-es2015-arrow-functions",
+      "transform-es2015-block-scoping"
+    ]
   }
 }

--- a/test/test_memoize.js
+++ b/test/test_memoize.js
@@ -2,6 +2,10 @@
 
 'use strict';
 
+if (typeof Promise === 'undefined') {
+  global.Promise = require('any-promise');
+}
+
 const assert  = require('assert');
 const co      = require('co');
 const memoize = require('../');


### PR DESCRIPTION
Support older versions of node (0.10) via transpiling into /es5 with babel, so, with older versions of node, you just require with

``` js
var promiseMemoize = require('promise-memoize/es5')
```

_grumble grumble vendor still hasn't upgraded off of 0.10_
