### PR TITLE
Update memoize.js

### DIFF
--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -40,7 +40,9 @@ function destroyCacheObj(cache, key) {
 
 
 function askPrefetch(cache, key) {
-  cache[key].need_prefetch = true;
+  if(cache[key] != null){
+    cache[key].need_prefetch = true;
+  }
 }
 
 


### PR DESCRIPTION
In environments where the event loop takes longer to return than the timeout interval (this is possible with very short timeout intervals or very long running synchronous functions), it's possible for `destroyCacheObj` to run before `askPrefetch`, which creates a situation where `askPrefetch` will crash (and, at least in my case, take the entire application with it).