### PR TITLE
Allow function's "this" scope to be referenced

### DIFF
--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -126,7 +126,7 @@ function _prefetch_proceed(args) {
 
 
 function doPrefetch(cache, key, config) {
-  var result = ensurePromise(config.fn.apply(null, cache[key].args)),
+  var result = ensurePromise(config.fn.apply(config.fnthis, cache[key].args)),
       P      = result.constructor;
 
   cache[key].need_prefetch = false;
@@ -150,6 +150,7 @@ module.exports = function promiseMemoize(fn, options) {
       resolve     = resolver(_options.resolve),
       config      = {
         fn:          fn,
+        fnthis:      _options.fnthis || null,
         maxAge:      _options.maxAge || 0,
         maxErrorAge: _options.maxErrorAge || 0
       };
@@ -166,7 +167,7 @@ module.exports = function promiseMemoize(fn, options) {
 
     } else {
       cache[key] = createCacheObj(
-        ensurePromise(config.fn.apply(null, args)),
+        ensurePromise(config.fn.apply(config.fnthis, args)),
         config.maxAge || config.maxErrorAge ? args : null // Store args only if needed
       );
       trackCacheObj(cache, key, config);


### PR DESCRIPTION
Not sure if this is the correct approach but I needed to memoize functions of a class and they needed to refer to "this". 

The change works for me and is only adds a new option "fnthis" (better names more than welcome).